### PR TITLE
Global tierphysio manager integrity and auto-fix

### DIFF
--- a/appointments.php
+++ b/appointments.php
@@ -252,7 +252,7 @@ $csrfToken = csrf_token();
     </div>
     
     <!-- Add Appointment Modal -->
-    <div class="modal fade" id="addAppointmentModal" tabindex="-1" aria-labelledby="addAppointmentModalLabel" aria-hidden="true">
+    <div class="modal fade" id="addAppointmentModal" tabindex="-1" aria-labelledby="addAppointmentModalLabel" aria-hidden="true" style="z-index: 1055;">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">

--- a/includes/layout/footer.php
+++ b/includes/layout/footer.php
@@ -31,7 +31,7 @@
 </button>
 
 <!-- Changelog Modal -->
-<div class="modal fade" id="changelogModal" tabindex="-1" aria-labelledby="changelogModalLabel" aria-hidden="true">
+<div class="modal fade" id="changelogModal" tabindex="-1" aria-labelledby="changelogModalLabel" aria-hidden="true" style="z-index: 1055;">
     <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">

--- a/invoices.php
+++ b/invoices.php
@@ -331,7 +331,7 @@ $csrfToken = csrf_token();
     </div>
     
     <!-- Add Invoice Modal -->
-    <div class="modal fade" id="addInvoiceModal" tabindex="-1" aria-labelledby="addInvoiceModalLabel" aria-hidden="true">
+    <div class="modal fade" id="addInvoiceModal" tabindex="-1" aria-labelledby="addInvoiceModalLabel" aria-hidden="true" style="z-index: 1055;">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">

--- a/notes.php
+++ b/notes.php
@@ -442,7 +442,7 @@ $categories = [
     </div>
     
     <!-- Add Note Modal -->
-    <div class="modal fade" id="addNoteModal" tabindex="-1" aria-labelledby="addNoteModalLabel" aria-hidden="true">
+    <div class="modal fade" id="addNoteModal" tabindex="-1" aria-labelledby="addNoteModalLabel" aria-hidden="true" style="z-index: 1055;">
         <div class="modal-dialog modal-dialog-centered modal-lg">
             <div class="modal-content">
                 <div class="modal-header">

--- a/patients.php
+++ b/patients.php
@@ -364,7 +364,7 @@ $csrfToken = csrf_token();
     </div>
     
     <!-- Add Patient Modal -->
-    <div class="modal fade" id="addPatientModal" tabindex="-1" aria-labelledby="addPatientModalLabel" aria-hidden="true">
+    <div class="modal fade" id="addPatientModal" tabindex="-1" aria-labelledby="addPatientModalLabel" aria-hidden="true" style="z-index: 1055;">
         <div class="modal-dialog modal-dialog-centered modal-lg">
             <div class="modal-content">
                 <div class="modal-header">

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -719,6 +719,19 @@ html, body {
     position: static !important;
 }
 
+/* ===== Modal Z-Index Fix ===== */
+.modal {
+    z-index: 1055 !important;
+}
+
+.modal-backdrop {
+    z-index: 1050 !important;
+}
+
+.modal-dialog {
+    z-index: 1060 !important;
+}
+
 /* ===== Scrollbar ===== */
 ::-webkit-scrollbar {
     width: 8px;


### PR DESCRIPTION
Add `z-index` to modals and a global CSS rule to fix overlay issues and ensure modals are visible and clickable.

The integrity check reported modals without `z-index` and overlay issues. While individual modals were updated, a global CSS rule was added to `main.css` to ensure all modals consistently use `z-index: 1055` (Bootstrap standard) and prevent future inconsistencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f2a5dcb-8768-42c0-8f51-2f5e5ab4ed7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f2a5dcb-8768-42c0-8f51-2f5e5ab4ed7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

